### PR TITLE
feat: Resolve #7 - 表示設定UI（色変更、ワイヤーフレーム）

### DIFF
--- a/frontend/src/components/DisplaySettings.tsx
+++ b/frontend/src/components/DisplaySettings.tsx
@@ -1,0 +1,98 @@
+import { useCallback } from 'react'
+
+interface DisplaySettingsProps {
+  /** 現在のモデル色 */
+  modelColor: string
+  /** ワイヤーフレーム表示状態 */
+  wireframe: boolean
+  /** 色が変更された時のコールバック */
+  onColorChange: (color: string) => void
+  /** ワイヤーフレーム状態が変更された時のコールバック */
+  onWireframeChange: (enabled: boolean) => void
+}
+
+/**
+ * モデルの表示設定を変更するUIコンポーネント
+ *
+ * 機能:
+ * - カラーピッカーでモデルの色を変更
+ * - ワイヤーフレーム表示のON/OFF切り替え
+ */
+export function DisplaySettings({
+  modelColor,
+  wireframe,
+  onColorChange,
+  onWireframeChange,
+}: DisplaySettingsProps) {
+  const handleColorChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onColorChange(event.target.value)
+    },
+    [onColorChange]
+  )
+
+  const handleWireframeChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onWireframeChange(event.target.checked)
+    },
+    [onWireframeChange]
+  )
+
+  return (
+    <section
+      role="region"
+      aria-label="表示設定"
+      style={{
+        padding: '16px',
+        border: '1px solid #ccc',
+        borderRadius: '8px',
+        backgroundColor: '#f9f9f9',
+      }}
+    >
+      <h2 style={{ margin: '0 0 12px 0', fontSize: '16px' }}>表示設定</h2>
+
+      {/* カラーピッカー */}
+      <div style={{ marginBottom: '12px' }}>
+        <label
+          htmlFor="model-color"
+          style={{ display: 'block', color: '#666', marginBottom: '4px' }}
+        >
+          モデル色
+        </label>
+        <input
+          id="model-color"
+          type="color"
+          value={modelColor}
+          onChange={handleColorChange}
+          style={{
+            width: '100%',
+            height: '32px',
+            padding: '2px',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}
+        />
+      </div>
+
+      {/* ワイヤーフレームトグル */}
+      <div>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={wireframe}
+            onChange={handleWireframeChange}
+            style={{ marginRight: '8px' }}
+          />
+          <span>ワイヤーフレーム</span>
+        </label>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,1 +1,3 @@
 export { StlUpload } from './StlUpload'
+export { DisplaySettings } from './DisplaySettings'
+export { ModelInfoPanel } from './ModelInfoPanel'

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useDisplaySettings } from './useDisplaySettings'

--- a/frontend/src/hooks/useDisplaySettings.ts
+++ b/frontend/src/hooks/useDisplaySettings.ts
@@ -1,0 +1,89 @@
+import { useState, useCallback } from 'react'
+
+/**
+ * 表示設定のオプション
+ */
+interface UseDisplaySettingsOptions {
+  /** 初期のモデル色 */
+  initialColor?: string
+  /** 初期のワイヤーフレーム状態 */
+  initialWireframe?: boolean
+}
+
+/**
+ * 表示設定のフックの戻り値
+ */
+interface UseDisplaySettingsReturn {
+  /** 現在のモデル色 */
+  modelColor: string
+  /** ワイヤーフレーム表示状態 */
+  wireframe: boolean
+  /** モデル色を設定する */
+  setModelColor: (color: string) => void
+  /** ワイヤーフレーム状態を設定する */
+  setWireframe: (enabled: boolean) => void
+  /** ワイヤーフレーム状態をトグルする */
+  toggleWireframe: () => void
+  /** 設定を初期値にリセットする */
+  resetSettings: () => void
+}
+
+/** デフォルトのモデル色（グレー） */
+const DEFAULT_COLOR = '#808080'
+/** デフォルトのワイヤーフレーム状態 */
+const DEFAULT_WIREFRAME = false
+
+/**
+ * モデルの表示設定を管理するカスタムフック
+ *
+ * @param options 表示設定のオプション
+ * @returns 表示設定の状態と操作関数
+ *
+ * @example
+ * ```tsx
+ * const { modelColor, wireframe, setModelColor, setWireframe } = useDisplaySettings()
+ *
+ * // 色を変更
+ * setModelColor('#ff0000')
+ *
+ * // ワイヤーフレームをON
+ * setWireframe(true)
+ * ```
+ */
+export function useDisplaySettings(
+  options: UseDisplaySettingsOptions = {}
+): UseDisplaySettingsReturn {
+  const {
+    initialColor = DEFAULT_COLOR,
+    initialWireframe = DEFAULT_WIREFRAME,
+  } = options
+
+  const [modelColor, setModelColorState] = useState(initialColor)
+  const [wireframe, setWireframeState] = useState(initialWireframe)
+
+  const setModelColor = useCallback((color: string) => {
+    setModelColorState(color)
+  }, [])
+
+  const setWireframe = useCallback((enabled: boolean) => {
+    setWireframeState(enabled)
+  }, [])
+
+  const toggleWireframe = useCallback(() => {
+    setWireframeState((prev) => !prev)
+  }, [])
+
+  const resetSettings = useCallback(() => {
+    setModelColorState(initialColor)
+    setWireframeState(initialWireframe)
+  }, [initialColor, initialWireframe])
+
+  return {
+    modelColor,
+    wireframe,
+    setModelColor,
+    setWireframe,
+    toggleWireframe,
+    resetSettings,
+  }
+}

--- a/frontend/src/tests/DisplaySettings.test.tsx
+++ b/frontend/src/tests/DisplaySettings.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DisplaySettings } from '../components/DisplaySettings'
+
+describe('DisplaySettings', () => {
+  const defaultProps = {
+    modelColor: '#808080',
+    wireframe: false,
+    onColorChange: vi.fn(),
+    onWireframeChange: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('コンポーネントの表示', () => {
+    it('タイトル「表示設定」が表示される', () => {
+      render(<DisplaySettings {...defaultProps} />)
+      expect(screen.getByRole('heading', { name: '表示設定' })).toBeInTheDocument()
+    })
+
+    it('カラーピッカーが表示される', () => {
+      render(<DisplaySettings {...defaultProps} />)
+      const colorInput = screen.getByLabelText('モデル色')
+      expect(colorInput).toBeInTheDocument()
+      expect(colorInput).toHaveAttribute('type', 'color')
+    })
+
+    it('初期のモデル色が設定される', () => {
+      render(<DisplaySettings {...defaultProps} modelColor="#ff0000" />)
+      const colorInput = screen.getByLabelText('モデル色') as HTMLInputElement
+      expect(colorInput.value).toBe('#ff0000')
+    })
+
+    it('ワイヤーフレームトグルが表示される', () => {
+      render(<DisplaySettings {...defaultProps} />)
+      const checkbox = screen.getByRole('checkbox', { name: /ワイヤーフレーム/i })
+      expect(checkbox).toBeInTheDocument()
+    })
+
+    it('初期のワイヤーフレーム状態がOFFで表示される', () => {
+      render(<DisplaySettings {...defaultProps} wireframe={false} />)
+      const checkbox = screen.getByRole('checkbox', { name: /ワイヤーフレーム/i })
+      expect(checkbox).not.toBeChecked()
+    })
+
+    it('初期のワイヤーフレーム状態がONで表示される', () => {
+      render(<DisplaySettings {...defaultProps} wireframe={true} />)
+      const checkbox = screen.getByRole('checkbox', { name: /ワイヤーフレーム/i })
+      expect(checkbox).toBeChecked()
+    })
+  })
+
+  describe('色変更の操作', () => {
+    it('カラーピッカーで色を変更するとonColorChangeが呼ばれる', async () => {
+      const onColorChange = vi.fn()
+      render(<DisplaySettings {...defaultProps} onColorChange={onColorChange} />)
+
+      const colorInput = screen.getByLabelText('モデル色')
+      fireEvent.input(colorInput, { target: { value: '#ff5500' } })
+
+      expect(onColorChange).toHaveBeenCalledWith('#ff5500')
+    })
+
+    it('カラーピッカーで別の色に変更できる', async () => {
+      const onColorChange = vi.fn()
+      render(<DisplaySettings {...defaultProps} onColorChange={onColorChange} />)
+
+      const colorInput = screen.getByLabelText('モデル色')
+      fireEvent.input(colorInput, { target: { value: '#00ff00' } })
+
+      expect(onColorChange).toHaveBeenCalledWith('#00ff00')
+    })
+  })
+
+  describe('ワイヤーフレーム切り替えの操作', () => {
+    it('ワイヤーフレームをONにするとonWireframeChangeがtrueで呼ばれる', async () => {
+      const user = userEvent.setup()
+      const onWireframeChange = vi.fn()
+      render(
+        <DisplaySettings
+          {...defaultProps}
+          wireframe={false}
+          onWireframeChange={onWireframeChange}
+        />
+      )
+
+      const checkbox = screen.getByRole('checkbox', { name: /ワイヤーフレーム/i })
+      await user.click(checkbox)
+
+      expect(onWireframeChange).toHaveBeenCalledWith(true)
+    })
+
+    it('ワイヤーフレームをOFFにするとonWireframeChangeがfalseで呼ばれる', async () => {
+      const user = userEvent.setup()
+      const onWireframeChange = vi.fn()
+      render(
+        <DisplaySettings
+          {...defaultProps}
+          wireframe={true}
+          onWireframeChange={onWireframeChange}
+        />
+      )
+
+      const checkbox = screen.getByRole('checkbox', { name: /ワイヤーフレーム/i })
+      await user.click(checkbox)
+
+      expect(onWireframeChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('アクセシビリティ', () => {
+    it('セクションにregionロールとラベルが設定されている', () => {
+      render(<DisplaySettings {...defaultProps} />)
+      const section = screen.getByRole('region', { name: '表示設定' })
+      expect(section).toBeInTheDocument()
+    })
+  })
+
+  describe('デフォルト値', () => {
+    it('デフォルトの色は#808080（グレー）', () => {
+      render(<DisplaySettings {...defaultProps} modelColor="#808080" />)
+      const colorInput = screen.getByLabelText('モデル色') as HTMLInputElement
+      expect(colorInput.value).toBe('#808080')
+    })
+
+    it('デフォルトでワイヤーフレームはOFF', () => {
+      render(<DisplaySettings {...defaultProps} wireframe={false} />)
+      const checkbox = screen.getByRole('checkbox', { name: /ワイヤーフレーム/i })
+      expect(checkbox).not.toBeChecked()
+    })
+  })
+})

--- a/frontend/src/tests/useDisplaySettings.test.ts
+++ b/frontend/src/tests/useDisplaySettings.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDisplaySettings } from '../hooks/useDisplaySettings'
+
+describe('useDisplaySettings', () => {
+  describe('初期状態', () => {
+    it('デフォルトの色は#808080（グレー）', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+      expect(result.current.modelColor).toBe('#808080')
+    })
+
+    it('デフォルトでワイヤーフレームはfalse', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+      expect(result.current.wireframe).toBe(false)
+    })
+  })
+
+  describe('カスタム初期値', () => {
+    it('初期色を指定できる', () => {
+      const { result } = renderHook(() =>
+        useDisplaySettings({ initialColor: '#ff0000' })
+      )
+      expect(result.current.modelColor).toBe('#ff0000')
+    })
+
+    it('初期ワイヤーフレーム状態を指定できる', () => {
+      const { result } = renderHook(() =>
+        useDisplaySettings({ initialWireframe: true })
+      )
+      expect(result.current.wireframe).toBe(true)
+    })
+  })
+
+  describe('色の変更', () => {
+    it('setModelColorで色を変更できる', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+
+      act(() => {
+        result.current.setModelColor('#ff5500')
+      })
+
+      expect(result.current.modelColor).toBe('#ff5500')
+    })
+
+    it('色を複数回変更できる', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+
+      act(() => {
+        result.current.setModelColor('#ff0000')
+      })
+      expect(result.current.modelColor).toBe('#ff0000')
+
+      act(() => {
+        result.current.setModelColor('#00ff00')
+      })
+      expect(result.current.modelColor).toBe('#00ff00')
+    })
+  })
+
+  describe('ワイヤーフレームの切り替え', () => {
+    it('setWireframeでワイヤーフレームをONにできる', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+
+      act(() => {
+        result.current.setWireframe(true)
+      })
+
+      expect(result.current.wireframe).toBe(true)
+    })
+
+    it('setWireframeでワイヤーフレームをOFFにできる', () => {
+      const { result } = renderHook(() =>
+        useDisplaySettings({ initialWireframe: true })
+      )
+
+      act(() => {
+        result.current.setWireframe(false)
+      })
+
+      expect(result.current.wireframe).toBe(false)
+    })
+
+    it('toggleWireframeでワイヤーフレームを切り替えられる', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+
+      expect(result.current.wireframe).toBe(false)
+
+      act(() => {
+        result.current.toggleWireframe()
+      })
+      expect(result.current.wireframe).toBe(true)
+
+      act(() => {
+        result.current.toggleWireframe()
+      })
+      expect(result.current.wireframe).toBe(false)
+    })
+  })
+
+  describe('設定のリセット', () => {
+    it('resetSettingsでデフォルト値に戻せる', () => {
+      const { result } = renderHook(() => useDisplaySettings())
+
+      act(() => {
+        result.current.setModelColor('#ff0000')
+        result.current.setWireframe(true)
+      })
+
+      expect(result.current.modelColor).toBe('#ff0000')
+      expect(result.current.wireframe).toBe(true)
+
+      act(() => {
+        result.current.resetSettings()
+      })
+
+      expect(result.current.modelColor).toBe('#808080')
+      expect(result.current.wireframe).toBe(false)
+    })
+
+    it('カスタム初期値を指定した場合はその値に戻せる', () => {
+      const { result } = renderHook(() =>
+        useDisplaySettings({ initialColor: '#00ff00', initialWireframe: true })
+      )
+
+      act(() => {
+        result.current.setModelColor('#ff0000')
+        result.current.setWireframe(false)
+      })
+
+      act(() => {
+        result.current.resetSettings()
+      })
+
+      expect(result.current.modelColor).toBe('#00ff00')
+      expect(result.current.wireframe).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- 表示設定UIコンポーネント（DisplaySettings）を追加
- モデル色の変更とワイヤーフレーム表示切り替えの状態管理フック（useDisplaySettings）を追加
- カラーピッカーでモデル色を変更可能
- チェックボックスでワイヤーフレーム表示をON/OFF切り替え可能

## Changes

- `frontend/src/components/DisplaySettings.tsx` - 表示設定UIコンポーネント
- `frontend/src/hooks/useDisplaySettings.ts` - 表示設定の状態管理フック
- `frontend/src/tests/DisplaySettings.test.tsx` - コンポーネントのテスト
- `frontend/src/tests/useDisplaySettings.test.ts` - フックのテスト

## Test Results

- ✅ vitest: passed (60 tests)
- ✅ tsc: passed (no errors)
- ✅ eslint: passed (warnings only)
- ✅ build: passed

## Related Issue

Closes #7

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)