### PR TITLE
feat: Resolve #9 - スクリーンショット保存機能

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -40,3 +40,31 @@
 .read-the-docs {
   color: #888;
 }
+
+.info-section dd {
+  margin: 0;
+  text-align: right;
+  font-family: monospace;
+}
+
+.screenshot-section {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #3a3a3a;
+}
+
+.screenshot-btn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background 0.2s;
+}
+
+.screenshot-btn:hover {
+  background: #45a049;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,105 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useRef } from 'react'
+import { useSTLLoader } from './hooks/useSTLLoader'
+import { STLViewer } from './components/viewer'
+import type { STLViewerRef } from './components/viewer'
+import { downloadScreenshot } from './utils/screenshot'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { geometry, error, isLoading, loadFromFile, getModelInfo, reset } = useSTLLoader()
+  const modelInfo = getModelInfo()
+  const viewerRef = useRef<STLViewerRef>(null)
+
+  const handleScreenshot = () => {
+    const canvas = viewerRef.current?.takeScreenshot()
+    if (canvas) {
+      downloadScreenshot(canvas)
+    }
+  }
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (file) {
+      loadFromFile(file)
+    }
+  }
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    const file = event.dataTransfer.files[0]
+    if (file && file.name.toLowerCase().endsWith('.stl')) {
+      loadFromFile(file)
+    }
+  }
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <header className="header">
+        <h1>STL 3D Viewer</h1>
+        <div className="header-actions">
+          <label className="upload-btn">
+            Upload STL
+            <input
+              type="file"
+              accept=".stl"
+              onChange={handleFileChange}
+              style={{ display: 'none' }}
+            />
+          </label>
+          {geometry && (
+            <button onClick={reset} className="reset-btn">
+              Clear
+            </button>
+          )}
+        </div>
+      </header>
+
+      <main className="main">
+        <div
+          className="viewer-container"
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+        >
+          {isLoading && <div className="loading">Loading...</div>}
+          {error && <div className="error">{error}</div>}
+          {!geometry && !isLoading && !error && (
+            <div className="dropzone">
+              <p>Drop STL file here or click Upload</p>
+            </div>
+          )}
+          {geometry && <STLViewer ref={viewerRef} geometry={geometry} />}
+        </div>
+
+        {modelInfo && (
+          <aside className="sidebar">
+            <section className="info-section">
+              <h2>Model Info</h2>
+              <dl>
+                <dt>Vertices</dt>
+                <dd>{modelInfo.vertexCount.toLocaleString()}</dd>
+                <dt>Faces</dt>
+                <dd>{modelInfo.faceCount.toLocaleString()}</dd>
+                <dt>Size X</dt>
+                <dd>{modelInfo.boundingBox.x.toFixed(2)}</dd>
+                <dt>Size Y</dt>
+                <dd>{modelInfo.boundingBox.y.toFixed(2)}</dd>
+                <dt>Size Z</dt>
+                <dd>{modelInfo.boundingBox.z.toFixed(2)}</dd>
+              </dl>
+            </section>
+            <section className="screenshot-section">
+              <button onClick={handleScreenshot} className="screenshot-btn">
+                Screenshot
+              </button>
+            </section>
+          </aside>
+        )}
+      </main>
+    </div>
   )
 }
 

--- a/frontend/src/__tests__/Screenshot.test.tsx
+++ b/frontend/src/__tests__/Screenshot.test.tsx
@@ -1,0 +1,133 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+// Mock Three.js WebGLRenderer
+vi.mock('three', async () => {
+  const actual = await vi.importActual('three')
+  return {
+    ...actual,
+    WebGLRenderer: vi.fn().mockImplementation(() => ({
+      setSize: vi.fn(),
+      setPixelRatio: vi.fn(),
+      render: vi.fn(),
+      dispose: vi.fn(),
+      domElement: document.createElement('canvas'),
+    })),
+  }
+})
+
+// Mock @react-three/fiber
+vi.mock('@react-three/fiber', () => ({
+  Canvas: vi.fn(({ children }) => <div data-testid="canvas-mock">{children}</div>),
+  useThree: vi.fn(() => ({
+    gl: {
+      domElement: document.createElement('canvas'),
+      render: vi.fn(),
+    },
+    scene: {},
+    camera: {},
+  })),
+  useFrame: vi.fn(),
+}))
+
+// Mock @react-three/drei
+vi.mock('@react-three/drei', () => ({
+  OrbitControls: vi.fn(() => null),
+}))
+
+describe('Screenshot Feature', () => {
+  beforeEach(() => {
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('Screenshot Button', () => {
+    test('screenshot button exists when geometry is loaded', async () => {
+      // Import App dynamically to apply mocks
+      const { default: App } = await import('../App')
+      render(<App />)
+
+      // Initially, screenshot button should not be visible (no geometry loaded)
+      expect(screen.queryByText(/screenshot/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('useScreenshot Hook', () => {
+    test('useScreenshot hook should be exported', async () => {
+      const screenshotModule = await import('../hooks/useScreenshot')
+      expect(screenshotModule.useScreenshot).toBeDefined()
+    })
+
+    test('useScreenshot returns takeScreenshot function', async () => {
+      const { useScreenshot } = await import('../hooks/useScreenshot')
+      const { result } = await import('@testing-library/react').then(m => {
+        const { renderHook } = m
+        return renderHook(() => useScreenshot())
+      })
+
+      expect(result.current.takeScreenshot).toBeDefined()
+      expect(typeof result.current.takeScreenshot).toBe('function')
+    })
+  })
+
+  describe('Screenshot File Generation', () => {
+    test('generateScreenshotFilename creates correct filename format', async () => {
+      const { generateScreenshotFilename } = await import('../utils/screenshot')
+
+      // Mock Date
+      const mockDate = new Date('2025-11-26T12:30:45.000Z')
+      vi.setSystemTime(mockDate)
+
+      const filename = generateScreenshotFilename()
+      expect(filename).toMatch(/^stl-screenshot-\d{8}-\d{6}\.png$/)
+
+      vi.useRealTimers()
+    })
+
+    test('downloadScreenshot creates PNG download', async () => {
+      const { downloadScreenshot } = await import('../utils/screenshot')
+
+      // Mock canvas with toDataURL
+      const mockCanvas = document.createElement('canvas')
+      mockCanvas.toDataURL = vi.fn(() => 'data:image/png;base64,mockdata')
+
+      // Mock createElement for anchor
+      const mockAnchor = {
+        href: '',
+        download: '',
+        click: vi.fn(),
+      }
+      const originalCreateElement = document.createElement.bind(document)
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'a') {
+          return mockAnchor as unknown as HTMLAnchorElement
+        }
+        return originalCreateElement(tag)
+      })
+
+      downloadScreenshot(mockCanvas)
+
+      expect(mockCanvas.toDataURL).toHaveBeenCalledWith('image/png')
+      expect(mockAnchor.click).toHaveBeenCalled()
+      expect(mockAnchor.download).toMatch(/^stl-screenshot-.*\.png$/)
+    })
+  })
+
+  describe('STLViewer Screenshot Integration', () => {
+    test('STLViewer exports ref interface for screenshot', async () => {
+      // Verify the component exports the ref interface
+      const viewerModule = await import('../components/viewer/STLViewer')
+      const STLViewer = viewerModule.default
+
+      // forwardRef components are objects, not functions
+      expect(STLViewer).toBeDefined()
+      expect(typeof STLViewer).toBe('object')
+    })
+  })
+})

--- a/frontend/src/components/viewer/STLViewer.tsx
+++ b/frontend/src/components/viewer/STLViewer.tsx
@@ -1,3 +1,4 @@
+import { forwardRef, useImperativeHandle, useRef } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
@@ -7,20 +8,40 @@ interface STLViewerProps {
   geometry: THREE.BufferGeometry | null
 }
 
-export default function STLViewer({ geometry }: STLViewerProps) {
-  return (
-    <Canvas
-      camera={{ position: [0, 0, 5], fov: 50 }}
-      style={{ width: '100%', height: '100%' }}
-    >
-      <ambientLight intensity={0.5} />
-      <directionalLight position={[10, 10, 5]} intensity={1} />
-      <STLModel geometry={geometry} />
-      <OrbitControls
-        enableRotate={true}
-        enableZoom={true}
-        enablePan={true}
-      />
-    </Canvas>
-  )
+export interface STLViewerRef {
+  takeScreenshot: () => HTMLCanvasElement | null
 }
+
+const STLViewer = forwardRef<STLViewerRef, STLViewerProps>(({ geometry }, ref) => {
+  const canvasContainerRef = useRef<HTMLDivElement>(null)
+
+  useImperativeHandle(ref, () => ({
+    takeScreenshot: () => {
+      const canvas = canvasContainerRef.current?.querySelector('canvas')
+      return canvas || null
+    }
+  }), [])
+
+  return (
+    <div ref={canvasContainerRef} style={{ width: '100%', height: '100%' }}>
+      <Canvas
+        camera={{ position: [0, 0, 5], fov: 50 }}
+        style={{ width: '100%', height: '100%' }}
+        gl={{ preserveDrawingBuffer: true }}
+      >
+        <ambientLight intensity={0.5} />
+        <directionalLight position={[10, 10, 5]} intensity={1} />
+        <STLModel geometry={geometry} />
+        <OrbitControls
+          enableRotate={true}
+          enableZoom={true}
+          enablePan={true}
+        />
+      </Canvas>
+    </div>
+  )
+})
+
+STLViewer.displayName = 'STLViewer'
+
+export default STLViewer

--- a/frontend/src/components/viewer/index.ts
+++ b/frontend/src/components/viewer/index.ts
@@ -1,2 +1,3 @@
 export { default as STLViewer } from './STLViewer'
+export type { STLViewerRef } from './STLViewer'
 export { default as STLModel } from './STLModel'

--- a/frontend/src/hooks/useScreenshot.ts
+++ b/frontend/src/hooks/useScreenshot.ts
@@ -1,0 +1,26 @@
+import { useCallback, useRef } from 'react'
+import type { MutableRefObject } from 'react'
+import { downloadScreenshot } from '../utils/screenshot'
+
+interface UseScreenshotReturn {
+  takeScreenshot: () => void
+  canvasRef: MutableRefObject<HTMLCanvasElement | null>
+}
+
+/**
+ * Custom hook for taking screenshots of a canvas element
+ */
+export function useScreenshot(): UseScreenshotReturn {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  const takeScreenshot = useCallback(() => {
+    if (canvasRef.current) {
+      downloadScreenshot(canvasRef.current)
+    }
+  }, [])
+
+  return {
+    takeScreenshot,
+    canvasRef,
+  }
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { generateScreenshotFilename, downloadScreenshot } from './screenshot'

--- a/frontend/src/utils/screenshot.ts
+++ b/frontend/src/utils/screenshot.ts
@@ -1,0 +1,28 @@
+/**
+ * Generate a filename for screenshot with timestamp
+ * Format: stl-screenshot-YYYYMMDD-HHMMSS.png
+ */
+export function generateScreenshotFilename(): string {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  const seconds = String(now.getSeconds()).padStart(2, '0')
+
+  return `stl-screenshot-${year}${month}${day}-${hours}${minutes}${seconds}.png`
+}
+
+/**
+ * Download screenshot from canvas element
+ */
+export function downloadScreenshot(canvas: HTMLCanvasElement): void {
+  const dataURL = canvas.toDataURL('image/png')
+  const filename = generateScreenshotFilename()
+
+  const link = document.createElement('a')
+  link.href = dataURL
+  link.download = filename
+  link.click()
+}


### PR DESCRIPTION
## Summary

- Canvas要素からの画像取得機能を実装
- スクリーンショットボタンをサイドパネルに追加
- PNG形式でのダウンロード処理（stl-screenshot-{timestamp}.png）

## Changes

- `frontend/src/components/viewer/STLViewer.tsx`: forwardRefを適用し、ref経由でcanvas取得可能に
- `frontend/src/utils/screenshot.ts`: スクリーンショットのダウンロード処理とファイル名生成
- `frontend/src/hooks/useScreenshot.ts`: スクリーンショット用カスタムフック
- `frontend/src/App.tsx`: スクリーンショットボタンとハンドラーを追加
- `frontend/src/App.css`: スクリーンショットボタンのスタイル
- `docs/architecture/current_system.md`: アーキテクチャドキュメント更新

## Test Results

- ✅ vitest: passed (25 tests)
- ✅ eslint: passed
- ✅ tsc: passed
- ✅ build: passed

## Related Issue

Closes #9

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)